### PR TITLE
Add Hermes overlay protocol adapter and low-memory runtime/profile configs for Sophia voice overlay

### DIFF
--- a/design_plan.md
+++ b/design_plan.md
@@ -1,5 +1,29 @@
-# Requirements
+# Sophia Voice Overlay Refactor Plan
 
-# TODO
+## Current architecture review
+- Existing `voice-agent` implementation already separates concerns into STT, auth, LLM loop, and TTS pipeline.
+- Websocket server previously assumed a single native payload shape and lacked explicit Hermes overlay semantics.
+- STT defaults used a larger implicit model profile (`base`) not tuned for 5-10 GB RAM containers.
 
-# Testing
+## Refactor applied
+1. Added protocol adapter layer with `native_ws` and `hermes_overlay_v1` decoders.
+2. Added runtime/model profile settings in config to support memory-constrained deployments.
+3. Switched streaming STT model selection to config-driven values (default tiny/int8).
+4. Updated docs and dev config to align with Hermes overlay operation.
+
+## Deployment shape
+- Preferred as a lightweight sidecar container:
+  - Websocket ingress from Hermes runtime.
+  - Emits transcript/auth/tts events through shared run artifacts (DB + JSONL) and websocket acks.
+- Optional split into microservices later:
+  - `voice-ingress` (websocket + VAD)
+  - `voice-inference` (STT/TTS/LLM orchestration)
+  - `voice-auth` (speaker verification)
+
+## Suggested Hugging Face options under 5-10 GB RAM
+- STT: `faster-whisper tiny` or `base` int8 if latency allows.
+- TTS: Piper lightweight voice, or fallback synth if no model volume is mounted.
+- Avoid loading both heavyweight local LLM + larger STT in the same container.
+
+## Next integration step
+- Wire Hermes-agent to send `hermes_overlay_v1` envelope frames and consume ack/event stream.

--- a/voice-agent/README.md
+++ b/voice-agent/README.md
@@ -1,10 +1,29 @@
 # voice-agent
 
+A lightweight Sophia voice overlay service intended for Hermes-agent workflows.
+It keeps voice orchestration (STT/VAD/auth/TTS) separate from the core agent runtime
+and supports protocol adaptation for containerized communication.
+
+## Design goals
+- Overlay architecture: voice I/O is decoupled from core agent logic.
+- Container-friendly protocol: supports native websocket and `hermes_overlay_v1` envelope.
+- Low-memory defaults (5-10 GB target): tiny/int8 STT profile, fallback TTS, mock/openai-compatible LLM.
+
 ## Quickstart
 ```bash
 pip install -e .
 voice-agent serve --host 0.0.0.0 --port 8765 --config configs/dev.yaml
 ```
+
+## Protocols
+`server.protocol` in config controls websocket message parsing:
+- `native_ws`: `{type, payload}`
+- `hermes_overlay_v1`: `{protocol, frame: {type, payload}, meta}`
+
+## Recommended model profile (5-10 GB RAM)
+- STT: `faster-whisper tiny` with `int8`, `cpu_threads=2`
+- TTS: fallback (or Piper if prebuilt voice is available)
+- LLM: external API/OpenAI-compatible endpoint, keep local memory pressure low
 
 ## CLI
 ```bash

--- a/voice-agent/configs/dev.yaml
+++ b/voice-agent/configs/dev.yaml
@@ -1,13 +1,21 @@
 server:
   host: 0.0.0.0
   port: 8765
+  protocol: hermes_overlay_v1
 paths:
   artifacts_dir: runs
   workspace_dir: workspace
+runtime:
+  max_memory_gb: 8
+  allow_hf_downloads: false
 llm:
   provider: mock
+  system_prompt: "You are Sophia voice overlay for Hermes. Keep outputs short and task-focused."
 stt:
   refine_enabled: true
+  model_size: tiny
+  compute_type: int8
+  cpu_threads: 2
 vad:
   aggressiveness: 2
   energy_threshold: 0.005

--- a/voice-agent/src/voice_agent/config.py
+++ b/voice-agent/src/voice_agent/config.py
@@ -20,6 +20,9 @@ class STTConfig(BaseModel):
     window_ms: int = 5000
     overlap_ms: int = 1000
     refine_enabled: bool = True
+    model_size: str = "tiny"
+    compute_type: str = "int8"
+    cpu_threads: int = 2
 
 
 class VADConfig(BaseModel):
@@ -35,6 +38,9 @@ class LLMConfig(BaseModel):
     api_key: Optional[str] = None
     model: str = "local-model"
     max_steps: int = 4
+    system_prompt: str = (
+        "You are Sophia voice overlay for Hermes. Keep responses concise, actionable, and safe."
+    )
 
 
 class TTSConfig(BaseModel):
@@ -50,6 +56,12 @@ class PathsConfig(BaseModel):
 class ServerConfig(BaseModel):
     host: str = "0.0.0.0"
     port: int = 8765
+    protocol: str = "native_ws"
+
+
+class RuntimeConfig(BaseModel):
+    max_memory_gb: float = 8.0
+    allow_hf_downloads: bool = False
 
 
 class AppConfig(BaseModel):
@@ -60,6 +72,7 @@ class AppConfig(BaseModel):
     tts: TTSConfig = Field(default_factory=TTSConfig)
     paths: PathsConfig = Field(default_factory=PathsConfig)
     server: ServerConfig = Field(default_factory=ServerConfig)
+    runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
 
 
 def load_config(path: Optional[str]) -> AppConfig:

--- a/voice-agent/src/voice_agent/llm/ralph_loop.py
+++ b/voice-agent/src/voice_agent/llm/ralph_loop.py
@@ -45,7 +45,7 @@ class RalphLoop:
         workspace_state = ""
         for idx in range(self.config.llm.max_steps):
             prompt = (
-                f"You are a planner. Transcript: {transcript}. "
+                f"{self.config.llm.system_prompt} You are a planner. Transcript: {transcript}. "
                 f"Workspace: {workspace_state}. Provide next action and say DONE if finished."
             )
             plan = self.agents.get("planner").handler(prompt)

--- a/voice-agent/src/voice_agent/server/app.py
+++ b/voice-agent/src/voice_agent/server/app.py
@@ -8,12 +8,14 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from ..config import AppConfig, load_config
 from ..util.audio import b64decode
+from .protocols import build_protocol_adapter
 from .session_manager import SessionManager
 
 
 def create_app(config: AppConfig) -> FastAPI:
     app = FastAPI()
     manager = SessionManager(config, Path(config.paths.artifacts_dir))
+    protocol = build_protocol_adapter(config.server.protocol)
 
     @app.websocket("/ws")
     async def ws_endpoint(websocket: WebSocket) -> None:
@@ -22,8 +24,9 @@ def create_app(config: AppConfig) -> FastAPI:
             while True:
                 message = await websocket.receive_text()
                 data: Dict[str, Any] = json.loads(message)
-                msg_type = data.get("type")
-                payload = data.get("payload", {})
+                normalized = protocol.decode(data)
+                msg_type = normalized.msg_type
+                payload = normalized.payload
                 if msg_type == "start_session":
                     manager.start_session(
                         payload["session_id"],

--- a/voice-agent/src/voice_agent/server/protocols.py
+++ b/voice-agent/src/voice_agent/server/protocols.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class NormalizedMessage:
+    msg_type: str
+    payload: Dict[str, Any]
+
+
+class ProtocolAdapter:
+    def decode(self, data: Dict[str, Any]) -> NormalizedMessage:
+        raise NotImplementedError
+
+
+class NativeWsAdapter(ProtocolAdapter):
+    def decode(self, data: Dict[str, Any]) -> NormalizedMessage:
+        return NormalizedMessage(msg_type=data.get("type", ""), payload=data.get("payload", {}))
+
+
+class HermesOverlayAdapter(ProtocolAdapter):
+    """Accepts hermes-agent style envelope with transport metadata.
+
+    Expected input shape:
+    {
+      "protocol": "hermes_overlay_v1",
+      "frame": {"type": "audio_chunk", "payload": {...}},
+      "meta": {...}
+    }
+    """
+
+    def decode(self, data: Dict[str, Any]) -> NormalizedMessage:
+        frame = data.get("frame", {})
+        return NormalizedMessage(msg_type=frame.get("type", ""), payload=frame.get("payload", {}))
+
+
+def build_protocol_adapter(name: str) -> ProtocolAdapter:
+    if name == "hermes_overlay_v1":
+        return HermesOverlayAdapter()
+    return NativeWsAdapter()

--- a/voice-agent/src/voice_agent/stt/faster_whisper_stream.py
+++ b/voice-agent/src/voice_agent/stt/faster_whisper_stream.py
@@ -24,7 +24,11 @@ class StreamingTranscriber:
             return
         from faster_whisper import WhisperModel
 
-        self.model = WhisperModel("base", compute_type="int8")
+        self.model = WhisperModel(
+            self.config.model_size,
+            compute_type=self.config.compute_type,
+            cpu_threads=self.config.cpu_threads,
+        )
 
     def _decode(self, samples: np.ndarray) -> str:
         if self.model is None:


### PR DESCRIPTION
### Motivation
- Enable Sophia voice agent to act as a lightweight overlay for Hermes-style runtimes while preserving existing native websocket usage. 
- Provide explicit runtime and model-profile knobs so the service can be deployed in memory-constrained containers (target ~5–10 GB RAM). 
- Make STT/LLM behavior configurable to avoid loading heavyweight defaults in sidecar deployments.

### Description
- Added a protocol adapter layer (`voice-agent/src/voice_agent/server/protocols.py`) with `native_ws` and `hermes_overlay_v1` decoders and wired it into the websocket ingress in `create_app` so messages are normalized before handling. 
- Extended configuration (`voice-agent/src/voice_agent/config.py`) with STT profile fields (`model_size`, `compute_type`, `cpu_threads`), an LLM `system_prompt`, a server `protocol` field, and a `RuntimeConfig` for memory and HF-download control. 
- Made the streaming STT loader config-driven in `voice-agent/src/voice_agent/stt/faster_whisper_stream.py` so `WhisperModel` uses the configured model size/compute/threads instead of a hard-coded larger model. 
- Injected the overlay-specific system prompt into the LLM planning loop in `voice-agent/src/voice_agent/llm/ralph_loop.py`. 
- Updated docs and dev config (`voice-agent/README.md` and `voice-agent/configs/dev.yaml`) and added a short design plan describing the overlay architecture and low-memory recommendations.

### Testing
- Ran `pytest -q tests/test_end_to_end_replay.py` which initially errored with `ModuleNotFoundError` because the package wasn’t importable in that invocation. 
- Attempted `pip install -e .` which failed due to environment/network restrictions while resolving build dependencies (package index/network access prevented installing build deps). 
- Ran `PYTHONPATH=src pytest -q tests/test_end_to_end_replay.py` which executed but failed: the test harness raised an `AttributeError` about `FastAPI.add_event_handler` in this environment and ultimately a `ConnectionRefusedError` when the replay client attempted to connect, so end-to-end assertions could not be completed. 
- No automated tests passed end-to-end in this constrained environment; changes were validated by static inspection and local test runs where possible but full CI/e2e should be run in a normal network/runtime environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc0b2d7d08325bb93163dff4a3f8d)