### PR TITLE
Add clone dataset builder to voice-insight pipeline

### DIFF
--- a/voice-agent/README.md
+++ b/voice-agent/README.md
@@ -166,6 +166,18 @@ Without the insight extra, `build-voiceprint` refuses to create a production
 voiceprint. You can pass `--allow-fallback` only for smoke testing the graph
 write path; that fallback vector is not suitable for speaker identity.
 
+Build a balanced clone-training dataset from exported identity clips:
+
+```bash
+docker exec voice-agent-sophia-voice-1 python /app/scripts/voice_insight.py \
+  --config /app/configs/voice_insight.yaml build-clone-dataset --identity scott
+```
+
+This emits both `manifest.jsonl` and `metadata.csv` under
+`/ssd-ingest/voice-insight/training/<identity>/clone_dataset`, filtering out
+too-short/too-long segments and limiting per-recording samples so mixed source
+devices (dashcam, phone, recorder WAV) are represented.
+
 ## Protocols
 `server.protocol` in config controls websocket message parsing:
 - `native_ws`: `{type, payload}`

--- a/voice-agent/configs/voice_insight.yaml
+++ b/voice-agent/configs/voice_insight.yaml
@@ -29,6 +29,12 @@ voice_insight:
     max_segment_seconds: 18.0
     min_text_chars: 16
     max_samples_per_run: 100
+    clone_dataset:
+      min_segment_seconds: 3.0
+      max_segment_seconds: 14.0
+      min_text_chars: 20
+      max_samples: 400
+      max_samples_per_recording: 40
   legacy:
     speaker_seeds:
       # Add high-confidence legacy clusters here after reviewing the report.

--- a/voice-agent/scripts/voice_insight.py
+++ b/voice-agent/scripts/voice_insight.py
@@ -413,6 +413,80 @@ def build_voiceprint(
     }
 
 
+def _clean_transcript_for_clone(text: str) -> str:
+    cleaned = " ".join((text or "").strip().split())
+    return cleaned
+
+
+def build_clone_dataset(config: Dict[str, Any], identity: str, manifest: str | None = None) -> Dict[str, Any]:
+    train_cfg = training_config(config).get("clone_dataset", {})
+    min_seconds = float(train_cfg.get("min_segment_seconds", 3.0))
+    max_seconds = float(train_cfg.get("max_segment_seconds", 14.0))
+    min_text_chars = int(train_cfg.get("min_text_chars", 20))
+    max_samples = int(train_cfg.get("max_samples", 400))
+    max_samples_per_recording = int(train_cfg.get("max_samples_per_recording", 40))
+    if manifest:
+        with Path(manifest).open("r", encoding="utf-8") as handle:
+            rows = [json.loads(line) for line in handle if line.strip()]
+    else:
+        query = """
+        MATCH (:VoiceIdentity {identity_id: $identity})-[:HAS_TRAINING_SAMPLE]->(sample:VoiceTrainingSample)
+        WHERE sample.status = 'exported' AND coalesce(sample.container_path, sample.path) IS NOT NULL
+        RETURN sample.sample_id AS sample_id,
+               coalesce(sample.container_path, sample.path) AS path,
+               sample.recording_id AS recording_id,
+               sample.start_seconds AS start_seconds,
+               sample.end_seconds AS end_seconds,
+               sample.text AS text
+        ORDER BY sample.recording_id, sample.start_seconds
+        """
+        driver = driver_from_config(config)
+        with driver.session(database=target_db(config)) as session:
+            rows = [dict(record) for record in session.run(query, identity=identity)]
+        driver.close()
+    selected: List[Dict[str, Any]] = []
+    by_recording: Dict[str, int] = {}
+    for row in rows:
+        text = _clean_transcript_for_clone(str(row.get("text") or ""))
+        path = str(row.get("path") or row.get("container_path") or "")
+        start = float(row.get("start_seconds") or row.get("start") or 0.0)
+        end = float(row.get("end_seconds") or row.get("end") or 0.0)
+        duration = max(0.0, end - start)
+        recording_id = str(row.get("recording_id") or row.get("legacy_recording_key") or "unknown")
+        if len(text) < min_text_chars:
+            continue
+        if duration < min_seconds or duration > max_seconds:
+            continue
+        if not path or not Path(path).exists():
+            continue
+        if by_recording.get(recording_id, 0) >= max_samples_per_recording:
+            continue
+        selected.append({"path": path, "text": text, "duration_seconds": duration, "recording_id": recording_id})
+        by_recording[recording_id] = by_recording.get(recording_id, 0) + 1
+        if len(selected) >= max_samples:
+            break
+    out_root = Path(container_training_root(config)) / identity / "clone_dataset"
+    out_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_root / "manifest.jsonl"
+    metadata_path = out_root / "metadata.csv"
+    with manifest_path.open("w", encoding="utf-8") as handle:
+        for row in selected:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    with metadata_path.open("w", encoding="utf-8") as handle:
+        handle.write("audio_path|text|recording_id|duration_seconds\n")
+        for row in selected:
+            safe_text = row["text"].replace("|", " ")
+            handle.write(f"{row['path']}|{safe_text}|{row['recording_id']}|{row['duration_seconds']:.3f}\n")
+    return {
+        "identity": identity,
+        "samples_selected": len(selected),
+        "recordings_covered": len(by_recording),
+        "manifest": str(manifest_path),
+        "metadata_csv": str(metadata_path),
+        "database": target_db(config),
+    }
+
+
 def _chunks(rows: Iterable[Dict[str, Any]], size: int) -> Iterable[List[Dict[str, Any]]]:
     chunk: List[Dict[str, Any]] = []
     for row in rows:
@@ -590,6 +664,10 @@ def main() -> int:
     voiceprint.add_argument("--limit", type=int, default=200)
     voiceprint.add_argument("--allow-fallback", action="store_true")
 
+    clone = sub.add_parser("build-clone-dataset")
+    clone.add_argument("--identity", default=None)
+    clone.add_argument("--manifest")
+
     args = parser.parse_args()
     config = load_config(args.config)
 
@@ -645,6 +723,9 @@ def main() -> int:
                 indent=2,
             )
         )
+    elif args.command == "build-clone-dataset":
+        identity = args.identity or config.get("voice_insight", {}).get("default_identity", "scott")
+        print(json.dumps(build_clone_dataset(config, identity, manifest=args.manifest), indent=2))
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Prepare balanced, auditable training data for voice cloning separate from the voiceprint build so clone models can be trained from real exported speaker segments. 
- Improve dataset quality by filtering out too-short/too-long segments and ensuring diversity across source recordings (dashcam, phone, recorder). 

### Description
- Add a new CLI subcommand `build-clone-dataset` implemented in `voice_agent/scripts/voice_insight.py` that collects exported `VoiceTrainingSample` rows and selects samples for cloning with transcript and duration filters. 
- Introduce `_clean_transcript_for_clone` and `build_clone_dataset` functions that enforce `min/max` segment duration, `min_text_chars`, and a per-recording cap, and that emit `manifest.jsonl` and `metadata.csv` under the configured training root. 
- Add configuration knobs under `voice-agent/configs/voice_insight.yaml` in the `training.clone_dataset` section for `min_segment_seconds`, `max_segment_seconds`, `min_text_chars`, `max_samples`, and `max_samples_per_recording`. 
- Document the new workflow and output location in `voice-agent/README.md` and wire the new CLI parser/dispatch for `build-clone-dataset`. 

### Testing
- Ran byte-compile: `PYTHONPATH=voice-agent/src python -m py_compile voice-agent/scripts/voice_insight.py` which succeeded. 
- Verified CLI help: `PYTHONPATH=voice-agent/src python voice-agent/scripts/voice_insight.py --help` which initially failed when `PYTHONPATH` was not set (`ModuleNotFoundError`), and succeeded when `PYTHONPATH` was provided. 
- No additional unit tests were executed for the new dataset selection logic in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f61695d8c83258b198e790e7de013)