### PR TITLE
Add a strict-offline auto-router profile for Sophia

### DIFF
--- a/.github/workflows/voice-agent-hardening.yml
+++ b/.github/workflows/voice-agent-hardening.yml
@@ -37,7 +37,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
-      - name: Run live hardening and voice-contract tests
+      - name: Run live hardening, voice-contract, and router tests
         working-directory: voice-agent
         run: |
           pytest \
@@ -50,7 +50,8 @@ jobs:
             tests/test_neo4j_schema.py \
             tests/test_auth_state_taxonomy.py \
             tests/test_dispatch_bridge_auto_config.py \
-            tests/test_task_outbox.py
+            tests/test_task_outbox.py \
+            tests/test_auto_router_provider.py
 
       - name: Verify patch orchestrator dry run when present
         run: |

--- a/voice-agent/.env.example
+++ b/voice-agent/.env.example
@@ -23,21 +23,29 @@ NEO4J_DEFAULT_SPEAKER=scott
 # === Capture Storage ===
 SOPHIA_CAPTURE_DIR=/captures
 
-# === LLM Provider ===
-# Set to "openai" or "hermes" to enable real LLM responses.
-# Leave as "mock" to use a mock provider that echoes prompts.
-SOPHIA_INTENT_PROVIDER=mock
+# === LLM / auto-router ===
+# Recommended production profile: point Sophia only at the strict-offline
+# auto-router OpenAI-compatible API. Both root and /v1 URLs are accepted and
+# normalized. auto/* aliases are rejected when the host is public.
+SOPHIA_INTENT_PROVIDER=openai
+SOPHIA_INTENT_BASE_URL=http://auto-router:8088/v1
+SOPHIA_INTENT_API_KEY=local-offline-only
+SOPHIA_INTENT_MODEL=auto/fast
+SOPHIA_TASK_MODEL=auto/high-quality
 
-# Base URL for the OpenAI-compatible API endpoint.
-# For Hermes: http://host.docker.internal:8080/v1
-# For OpenAI: https://api.openai.com/v1
-SOPHIA_INTENT_BASE_URL=
+# Keep Sophia's retired in-process fleet discovery disabled. AssistX owns the
+# canonical runtime/model observations and auto-router owns request admission.
+SOPHIA_LOCAL_FLEET_DISCOVERY=false
 
-# API key if the endpoint requires one.
-SOPHIA_INTENT_API_KEY=
+# For a UI-only development session with no LLM, set:
+# SOPHIA_INTENT_PROVIDER=mock
+# SOPHIA_INTENT_BASE_URL=
 
-# Model name to use (e.g. gpt-4o, hermes-3-llama-3.1-8b, etc.)
-SOPHIA_INTENT_MODEL=draft-model
+# Request timeouts. Router 429/503 responses remain visible to Sophia and never
+# trigger hosted fallback.
+SOPHIA_LLM_TIMEOUT=60
+SOPHIA_TASK_TIMEOUT=60
+SOPHIA_TASK_EXTRACT_TIMEOUT=30
 
 # === Owner voiceprint override enrollment ===
 # Generate a strong local secret. Never commit a real token.

--- a/voice-agent/src/voice_agent/llm/openai_compat_provider.py
+++ b/voice-agent/src/voice_agent/llm/openai_compat_provider.py
@@ -1,16 +1,85 @@
 from __future__ import annotations
 
+import ipaddress
 import json
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
 from .provider_base import LLMProvider, LLMResponse
 
 
+AUTO_ROUTER_MODEL_PREFIX = "auto/"
+_LOCAL_HOST_SUFFIXES = (
+    ".lan",
+    ".local",
+    ".internal",
+    ".ts.net",
+)
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
 class LLMProviderError(Exception):
     """Raised when an OpenAI-compatible endpoint returns an error payload
     (including lmstudio's habit of replying with a plain JSON ``{"error": ...}``
     body and HTTP 200, which ``raise_for_status`` does not catch)."""
+
+
+def normalize_openai_base_url(base_url: str) -> str:
+    """Return an endpoint root that can safely receive ``/v1/...`` suffixes.
+
+    Operators commonly provide either ``http://router:8088`` or
+    ``http://router:8088/v1`` as an OpenAI base URL. The provider owns the
+    endpoint suffix, so normalize an optional trailing ``/v1`` to prevent
+    accidental requests to ``/v1/v1/chat/completions``.
+    """
+
+    raw = (base_url or "").strip()
+    if not raw:
+        raise ValueError("OpenAI-compatible base URL is required")
+    parsed = urlsplit(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError(f"Invalid OpenAI-compatible base URL: {base_url!r}")
+    path = parsed.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[:-3].rstrip("/")
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+
+
+def _is_private_router_host(hostname: str) -> bool:
+    host = hostname.strip().lower().rstrip(".")
+    if host in {"localhost", "host.docker.internal"}:
+        return True
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        # Single-label names are local Docker/LAN service names. Qualified
+        # names must use an explicitly local or Tailscale suffix.
+        return "." not in host or host.endswith(_LOCAL_HOST_SUFFIXES)
+    return (
+        address.is_loopback
+        or address.is_private
+        or address.is_link_local
+        or address in _CGNAT_NETWORK
+    )
+
+
+def validate_auto_router_base_url(base_url: str) -> str:
+    """Normalize and reject public endpoints for ``auto/*`` model aliases.
+
+    auto-router's aliases are strict-offline contracts. A Sophia deployment
+    using one of those aliases must not silently point at OpenAI, OpenRouter, or
+    another public gateway.
+    """
+
+    normalized = normalize_openai_base_url(base_url)
+    host = urlsplit(normalized).hostname or ""
+    if not _is_private_router_host(host):
+        raise ValueError(
+            "auto-router model aliases require a local, LAN, Docker, or "
+            f"Tailscale base URL; received host {host!r}"
+        )
+    return normalized
 
 
 def _raise_if_error(obj: object) -> None:
@@ -36,12 +105,22 @@ class OpenAICompatProvider(LLMProvider):
         task_model: str | None = None,
         task_timeout: float | None = None,
     ):
-        self.base_url = base_url.rstrip("/")
+        resolved_task_model = task_model or model
+        uses_auto_router = any(
+            candidate.startswith(AUTO_ROUTER_MODEL_PREFIX)
+            for candidate in (model, resolved_task_model)
+        )
+        self.base_url = (
+            validate_auto_router_base_url(base_url)
+            if uses_auto_router
+            else normalize_openai_base_url(base_url)
+        )
         self.api_key = api_key
         self.model = model
-        self.task_model = task_model or model
+        self.task_model = resolved_task_model
         self.timeout = timeout
         self.task_timeout = task_timeout or timeout
+        self.uses_auto_router = uses_auto_router
 
     def complete(self, prompt: str, timeout: float | None = None) -> LLMResponse:
         headers = {"Content-Type": "application/json"}
@@ -53,7 +132,12 @@ class OpenAICompatProvider(LLMProvider):
                 {"role": "user", "content": prompt},
             ],
         }
-        resp = requests.post(f"{self.base_url}/v1/chat/completions", headers=headers, json=payload, timeout=timeout if timeout is not None else self.task_timeout)
+        resp = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=timeout if timeout is not None else self.task_timeout,
+        )
         resp.raise_for_status()
         try:
             data = resp.json()

--- a/voice-agent/tests/test_auto_router_provider.py
+++ b/voice-agent/tests/test_auto_router_provider.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from voice_agent.llm.openai_compat_provider import (
+    OpenAICompatProvider,
+    normalize_openai_base_url,
+    validate_auto_router_base_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("http://auto-router:8088", "http://auto-router:8088"),
+        ("http://auto-router:8088/", "http://auto-router:8088"),
+        ("http://auto-router:8088/v1", "http://auto-router:8088"),
+        ("http://host.docker.internal:8088/v1/", "http://host.docker.internal:8088"),
+        ("http://127.0.0.1:8088/prefix/v1", "http://127.0.0.1:8088/prefix"),
+    ],
+)
+def test_normalize_openai_base_url(raw: str, expected: str) -> None:
+    assert normalize_openai_base_url(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://auto-router:8088/v1",
+        "http://host.docker.internal:8088",
+        "http://127.0.0.1:8088",
+        "http://192.168.1.51:8088",
+        "http://100.90.80.70:8088",
+        "http://router.lan:8088",
+        "https://router.example.ts.net:8088/v1",
+    ],
+)
+def test_auto_router_alias_accepts_private_hosts(url: str) -> None:
+    provider = OpenAICompatProvider(
+        url,
+        "local-only",
+        "auto/fast",
+        task_model="auto/high-quality",
+    )
+    assert provider.uses_auto_router is True
+    assert not provider.base_url.endswith("/v1")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.openai.com/v1",
+        "https://openrouter.ai/api/v1",
+        "http://8.8.8.8:8088/v1",
+        "https://router.example.com/v1",
+    ],
+)
+def test_auto_router_alias_rejects_public_hosts(url: str) -> None:
+    with pytest.raises(ValueError, match="require a local"):
+        OpenAICompatProvider(url, "secret", "auto/fast")
+
+
+def test_non_router_model_retains_openai_compatibility() -> None:
+    provider = OpenAICompatProvider(
+        "https://api.openai.com/v1",
+        "secret",
+        "gpt-example",
+    )
+    assert provider.uses_auto_router is False
+    assert provider.base_url == "https://api.openai.com"
+
+
+def test_validate_auto_router_base_url_rejects_invalid_url() -> None:
+    with pytest.raises(ValueError, match="Invalid OpenAI-compatible"):
+        validate_auto_router_base_url("not-a-url")
+
+
+@dataclass
+class _Response:
+    payload: dict
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self.payload
+
+
+def test_task_alias_uses_single_v1_path_and_high_quality_model(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        captured["url"] = url
+        captured["payload"] = json
+        captured["headers"] = headers
+        return _Response({"choices": [{"message": {"content": "[]"}}]})
+
+    monkeypatch.setattr(
+        "voice_agent.llm.openai_compat_provider.requests.post",
+        fake_post,
+    )
+    provider = OpenAICompatProvider(
+        "http://auto-router:8088/v1",
+        "local-offline-only",
+        "auto/fast",
+        task_model="auto/high-quality",
+    )
+
+    response = provider.complete("extract tasks")
+
+    assert response.content == "[]"
+    assert captured["url"] == "http://auto-router:8088/v1/chat/completions"
+    assert captured["payload"]["model"] == "auto/high-quality"
+    assert captured["headers"]["Authorization"] == "Bearer local-offline-only"


### PR DESCRIPTION
## Summary

Prepare Sophia's existing OpenAI-compatible provider to use auto-router as the first-class inference path without giving Sophia fleet-placement authority. PR #8 is now merged; this branch has been rebuilt cleanly on the resulting `master` commit.

## Changes

- Normalize operator-supplied endpoint roots so both `http://router:8088` and `http://router:8088/v1` produce exactly one `/v1/chat/completions` path.
- Detect auto-router contracts through `auto/*` model aliases.
- Reject public endpoints when an `auto/*` alias is configured.
- Allow loopback, RFC1918, Tailscale CGNAT, approved `.ts.net`/`.lan`/`.local`/`.internal` names, `host.docker.internal`, and single-label Docker service names.
- Document the recommended Sophia profile:
  - interactive voice/chat: `auto/fast`
  - task extraction: `auto/high-quality`
  - local-only API key placeholder
  - Sophia fleet discovery disabled
- Add provider tests for URL normalization, private-host admission, public-host rejection, alias selection, and the final task request path.
- Add the router test module to the repaired hardening workflow.

## Authority boundary

- Sophia chooses a logical workload alias only.
- auto-router owns local request normalization, candidate selection, admission, and backpressure.
- AssistX remains the canonical runtime/model/task authority.
- This change does not introduce hosted fallback or direct fleet-node probing.

## Validation

The original stacked branch passed GitHub Actions run `30815705665`. This clean branch rewrite must pass a fresh workflow run before merge.

## Follow-up

Issue #9 remains open for correlation/QoS metadata, route provenance display, explicit 429/503 UX, and eventual removal of the legacy in-process fleet discovery implementation.
