### PR TITLE
Preserve auto-router QoS and route provenance in Sophia

### DIFF
--- a/voice-agent/src/voice_agent/llm/openai_compat_provider.py
+++ b/voice-agent/src/voice_agent/llm/openai_compat_provider.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import time
+import uuid
+from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
@@ -17,12 +20,29 @@ _LOCAL_HOST_SUFFIXES = (
     ".ts.net",
 )
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+_ROUTE_HEADER_MAP = {
+    "x-auto-router-provider": "provider",
+    "x-auto-router-model": "model",
+    "x-auto-router-stage": "stage",
+    "x-auto-router-profile": "profile",
+}
 
 
 class LLMProviderError(Exception):
-    """Raised when an OpenAI-compatible endpoint returns an error payload
-    (including lmstudio's habit of replying with a plain JSON ``{"error": ...}``
-    body and HTTP 200, which ``raise_for_status`` does not catch)."""
+    """Structured failure from an OpenAI-compatible inference endpoint."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        retry_after_seconds: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.retry_after_seconds = retry_after_seconds
+        self.metadata = dict(metadata or {})
 
 
 def normalize_openai_base_url(base_url: str) -> str:
@@ -95,6 +115,65 @@ def _raise_if_error(obj: object) -> None:
     raise LLMProviderError("LLM endpoint error: " + str(msg))
 
 
+def _coerce_retry_after(value: Any) -> int | None:
+    try:
+        return max(int(float(str(value))), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _response_headers(resp: Any) -> dict[str, str]:
+    raw_headers = getattr(resp, "headers", {}) or {}
+    try:
+        return {str(key).lower(): str(value) for key, value in raw_headers.items()}
+    except AttributeError:
+        return {}
+
+
+def _error_detail(payload: Any) -> str:
+    if isinstance(payload, dict):
+        detail = payload.get("detail") or payload.get("error")
+        if isinstance(detail, dict):
+            return str(
+                detail.get("message")
+                or detail.get("error")
+                or detail.get("detail")
+                or detail
+            )
+        if detail is not None:
+            return str(detail)
+    return "upstream inference request failed"
+
+
+def _raise_for_http_error(resp: Any) -> None:
+    status_code = int(getattr(resp, "status_code", 200) or 200)
+    if status_code < 400:
+        resp.raise_for_status()
+        return
+    try:
+        payload = resp.json()
+    except Exception:
+        payload = None
+    headers = _response_headers(resp)
+    retry_after = _coerce_retry_after(headers.get("retry-after"))
+    detail = _error_detail(payload)
+    if status_code == 503:
+        message = (
+            "auto-router has no admitted local capacity; "
+            f"request was not sent to a hosted provider: {detail}"
+        )
+    elif status_code == 429:
+        message = f"auto-router admission is saturated: {detail}"
+    else:
+        message = f"LLM endpoint returned HTTP {status_code}: {detail}"
+    raise LLMProviderError(
+        message,
+        status_code=status_code,
+        retry_after_seconds=retry_after,
+        metadata={"retry_after_seconds": retry_after},
+    )
+
+
 class OpenAICompatProvider(LLMProvider):
     def __init__(
         self,
@@ -121,81 +200,215 @@ class OpenAICompatProvider(LLMProvider):
         self.timeout = timeout
         self.task_timeout = task_timeout or timeout
         self.uses_auto_router = uses_auto_router
+        self.last_route_metadata: dict[str, Any] = {}
 
-    def complete(self, prompt: str, timeout: float | None = None) -> LLMResponse:
+    def _headers(self) -> dict[str, str]:
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
-        payload = {
+        return headers
+
+    def _request_metadata(
+        self,
+        workload_class: str,
+        *,
+        latency_target_ms: int,
+        overrides: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "correlation_id": str(uuid.uuid4()),
+            "source_repo": "Sophia",
+            "source_service": "voice-agent",
+            "workload_class": workload_class,
+            "privacy": "personal",
+            "local_only": True,
+            "allow_cloud": False,
+            "priority": "interactive",
+            "latency_target_ms": latency_target_ms,
+            "queued_at_ms": int(time.time() * 1000),
+        }
+        if overrides:
+            metadata.update(
+                {
+                    str(key): value
+                    for key, value in overrides.items()
+                    if value is not None
+                }
+            )
+        # An auto/* alias is a strict-offline contract. Caller overrides may
+        # enrich the request but cannot weaken local/privacy admission.
+        metadata["privacy"] = "personal"
+        metadata["local_only"] = True
+        metadata["allow_cloud"] = False
+        return metadata
+
+    def _route_metadata(
+        self,
+        resp: Any,
+        *,
+        requested_model: str,
+        request_metadata: dict[str, Any],
+        payload: Any | None = None,
+    ) -> dict[str, Any]:
+        route: dict[str, Any] = {
+            "correlation_id": request_metadata.get("correlation_id"),
+            "session_id": request_metadata.get("session_id"),
+            "workload_class": request_metadata.get("workload_class"),
+            "requested_model": requested_model,
+            "status_code": int(getattr(resp, "status_code", 200) or 200),
+        }
+        if isinstance(payload, dict) and isinstance(payload.get("auto_router"), dict):
+            route.update(payload["auto_router"])
+        headers = _response_headers(resp)
+        for header, key in _ROUTE_HEADER_MAP.items():
+            if headers.get(header):
+                route[key] = headers[header]
+        retry_after = _coerce_retry_after(headers.get("retry-after"))
+        if retry_after is not None:
+            route["retry_after_seconds"] = retry_after
+        return {key: value for key, value in route.items() if value is not None}
+
+    def complete(
+        self,
+        prompt: str,
+        timeout: float | None = None,
+        request_metadata: dict[str, Any] | None = None,
+    ) -> LLMResponse:
+        metadata = self._request_metadata(
+            "task_extraction",
+            latency_target_ms=10_000,
+            overrides=request_metadata,
+        )
+        payload: dict[str, Any] = {
             "model": self.task_model,
             "messages": [
                 {"role": "user", "content": prompt},
             ],
         }
+        if self.uses_auto_router:
+            payload["metadata"] = metadata
+        started = time.perf_counter()
         resp = requests.post(
             f"{self.base_url}/v1/chat/completions",
-            headers=headers,
+            headers=self._headers(),
             json=payload,
             timeout=timeout if timeout is not None else self.task_timeout,
         )
-        resp.raise_for_status()
+        try:
+            _raise_for_http_error(resp)
+        except LLMProviderError as exc:
+            self.last_route_metadata = {
+                **metadata,
+                "requested_model": self.task_model,
+                "status_code": exc.status_code,
+                "retry_after_seconds": exc.retry_after_seconds,
+                "latency_ms": int((time.perf_counter() - started) * 1000),
+                "error": str(exc),
+            }
+            raise
         try:
             data = resp.json()
-        except ValueError:
-            raise LLMProviderError("LLM returned a non-JSON response body")
+        except ValueError as exc:
+            raise LLMProviderError("LLM returned a non-JSON response body") from exc
         _raise_if_error(data)
         content = data["choices"][0]["message"]["content"]
-        return LLMResponse(content=content)
+        route = self._route_metadata(
+            resp,
+            requested_model=self.task_model,
+            request_metadata=metadata,
+            payload=data,
+        )
+        route["latency_ms"] = int((time.perf_counter() - started) * 1000)
+        self.last_route_metadata = route
+        return LLMResponse(content=content, metadata=route)
 
-    def stream_complete(self, messages, *, temperature: float = 0.7, max_tokens: int = 800):
-        headers = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-        payload = {
+    def stream_complete(
+        self,
+        messages,
+        *,
+        temperature: float = 0.7,
+        max_tokens: int = 800,
+        request_metadata: dict[str, Any] | None = None,
+    ):
+        metadata = self._request_metadata(
+            "interactive_voice",
+            latency_target_ms=1_500,
+            overrides=request_metadata,
+        )
+        payload: dict[str, Any] = {
             "model": self.model,
             "messages": messages,
             "stream": True,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
+        if self.uses_auto_router:
+            payload["metadata"] = metadata
+        started = time.perf_counter()
         resp = requests.post(
             f"{self.base_url}/v1/chat/completions",
-            headers=headers,
+            headers=self._headers(),
             json=payload,
             stream=True,
             timeout=self.timeout,
         )
-        resp.raise_for_status()
-        for raw in resp.iter_lines():
-            if not raw:
-                continue
-            line = raw.decode("utf-8") if isinstance(raw, bytes) else raw
-            if line.startswith("data:"):
-                data = line[len("data:"):].strip()
-                if data == "[DONE]":
-                    break
-                try:
-                    obj = json.loads(data)
-                except Exception:
+        try:
+            _raise_for_http_error(resp)
+        except LLMProviderError as exc:
+            self.last_route_metadata = {
+                **metadata,
+                "requested_model": self.model,
+                "status_code": exc.status_code,
+                "retry_after_seconds": exc.retry_after_seconds,
+                "latency_ms": int((time.perf_counter() - started) * 1000),
+                "error": str(exc),
+            }
+            raise
+        route = self._route_metadata(
+            resp,
+            requested_model=self.model,
+            request_metadata=metadata,
+        )
+        first_token_at: float | None = None
+        try:
+            for raw in resp.iter_lines():
+                if not raw:
                     continue
-                _raise_if_error(obj)
-                try:
-                    delta = obj["choices"][0]["delta"].get("content")
-                    if not delta:
-                        # Some local/reasoning models stream their output under
-                        # reasoning_content instead of content; surface it so the
-                        # caller still sees a response.
-                        delta = obj["choices"][0]["delta"].get("reasoning_content")
-                    if delta:
-                        yield delta
-                except Exception:
-                    continue
-            else:
-                # Non-SSE body: lmstudio frequently returns a plain JSON error
-                # object (not wrapped in `data:`) with HTTP 200. Surface it so
-                # the caller can retry against another endpoint.
-                try:
-                    obj = json.loads(line)
-                except Exception:
-                    continue
-                _raise_if_error(obj)
+                line = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+                if line.startswith("data:"):
+                    data = line[len("data:"):].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        obj = json.loads(data)
+                    except Exception:
+                        continue
+                    _raise_if_error(obj)
+                    try:
+                        delta = obj["choices"][0]["delta"].get("content")
+                        if not delta:
+                            # Some local/reasoning models stream their output under
+                            # reasoning_content instead of content; surface it so the
+                            # caller still sees a response.
+                            delta = obj["choices"][0]["delta"].get("reasoning_content")
+                        if delta:
+                            if first_token_at is None:
+                                first_token_at = time.perf_counter()
+                            yield delta
+                    except Exception:
+                        continue
+                else:
+                    # Non-SSE body: lmstudio frequently returns a plain JSON error
+                    # object (not wrapped in `data:`) with HTTP 200. Surface it so
+                    # the caller can retry against another endpoint.
+                    try:
+                        obj = json.loads(line)
+                    except Exception:
+                        continue
+                    _raise_if_error(obj)
+        finally:
+            ended = time.perf_counter()
+            route["latency_ms"] = int((ended - started) * 1000)
+            if first_token_at is not None:
+                route["ttft_ms"] = int((first_token_at - started) * 1000)
+            self.last_route_metadata = route

--- a/voice-agent/src/voice_agent/llm/provider_base.py
+++ b/voice-agent/src/voice_agent/llm/provider_base.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
 class LLMResponse:
     content: str
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class LLMProvider:

--- a/voice-agent/src/voice_agent/server/assistant.py
+++ b/voice-agent/src/voice_agent/server/assistant.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from ..config import AppConfig
 from ..llm.openai_compat_provider import LLMProviderError, OpenAICompatProvider
-from ..llm.provider_base import LLMProvider, MockProvider
+from ..llm.provider_base import LLMProvider, LLMResponse, MockProvider
 from .assistx_dispatch import build_voice_event, dispatch_to_assistx
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,10 @@ class Assistant:
         # SOPHIA_LOCAL_FLEET_DISCOVERY flag (or config local_fleet_discovery)
         # enables the legacy in-tree discoverer.
         if getattr(config.llm, "local_fleet_discovery", False):
+            logger.warning(
+                "SOPHIA_LOCAL_FLEET_DISCOVERY is deprecated; auto-router and "
+                "AssistX must own fleet placement in production"
+            )
             self._init_fleet()
 
     def _init_fleet(self) -> None:
@@ -64,9 +68,7 @@ class Assistant:
             )
             self.discoverer.start()
         except Exception as exc:  # discovery is best-effort; fall back to config provider
-            import logging
-
-            logging.getLogger(__name__).warning("fleet discovery failed to start: %s", exc)
+            logger.warning("fleet discovery failed to start: %s", exc)
             self.discoverer = None
 
     def _provider_for(self, ep) -> LLMProvider | None:
@@ -179,6 +181,82 @@ class Assistant:
             parts.append(str(context.get("note")))
         return "\n".join(parts)
 
+    def _router_request_metadata(
+        self,
+        context: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if not isinstance(context, dict):
+            return {}
+        metadata: dict[str, Any] = {}
+        for key in (
+            "session_id",
+            "correlation_id",
+            "device_id",
+            "user_id",
+            "activity",
+            "timezone",
+        ):
+            value = context.get(key)
+            if value is not None and value != "":
+                metadata[key] = value
+        return metadata
+
+    def _route_label(self, provider: LLMProvider, fallback: str) -> str:
+        route = getattr(provider, "last_route_metadata", None)
+        if not isinstance(route, dict) or not route:
+            return fallback
+        selected_provider = route.get("provider")
+        selected_model = route.get("model") or route.get("requested_model")
+        selected = "/".join(
+            str(value)
+            for value in (selected_provider, selected_model)
+            if value
+        ) or fallback
+        profile = route.get("profile")
+        stage = route.get("stage")
+        tags = ":".join(str(value) for value in (profile, stage) if value)
+        metrics: list[str] = []
+        if route.get("ttft_ms") is not None:
+            metrics.append(f"ttft={route['ttft_ms']}ms")
+        if route.get("latency_ms") is not None:
+            metrics.append(f"latency={route['latency_ms']}ms")
+        label = f"router:{selected}"
+        if tags:
+            label += f" [{tags}]"
+        if metrics:
+            label += " " + " ".join(metrics)
+        return label
+
+    def _stream_provider(
+        self,
+        provider: LLMProvider,
+        messages: list[dict[str, Any]],
+        request_metadata: dict[str, Any],
+    ) -> Iterator[str]:
+        if isinstance(provider, OpenAICompatProvider):
+            yield from provider.stream_complete(
+                messages,
+                request_metadata=request_metadata,
+            )
+            return
+        yield from provider.stream_complete(messages)
+
+    def _complete_provider(
+        self,
+        provider: LLMProvider,
+        prompt: str,
+        *,
+        timeout: float,
+        request_metadata: dict[str, Any],
+    ) -> LLMResponse:
+        if isinstance(provider, OpenAICompatProvider):
+            return provider.complete(
+                prompt,
+                timeout=timeout,
+                request_metadata=request_metadata,
+            )
+        return provider.complete(prompt)
+
     def _prepare_messages(self, messages: list[dict[str, Any]], context: dict[str, Any] | None) -> list[dict[str, Any]]:
         msgs: list[dict[str, Any]] = [dict(m) for m in messages]
         ctx_str = self._format_context(context)
@@ -212,11 +290,17 @@ class Assistant:
 
     def stream_reply(self, messages: list[dict[str, Any]], context: dict[str, Any] | None = None) -> Iterator[str]:
         msgs = self._prepare_messages(messages, context)
+        request_metadata = self._router_request_metadata(context)
         eps = self._candidate_endpoints("chat")
         if not eps:
             try:
-                yield from self.provider.stream_complete(msgs)
-                self._last_chat_endpoint = "config:" + getattr(self.provider, "model", "config")
+                yield from self._stream_provider(
+                    self.provider,
+                    msgs,
+                    request_metadata,
+                )
+                fallback = "config:" + getattr(self.provider, "model", "config")
+                self._last_chat_endpoint = self._route_label(self.provider, fallback)
                 return
             except Exception as exc:
                 logger.warning("configured chat provider failed: %s", exc)
@@ -224,9 +308,9 @@ class Assistant:
         for ep in eps:
             provider = self._provider_for(ep) or self.provider
             try:
-                yield from provider.stream_complete(msgs)
+                yield from self._stream_provider(provider, msgs, request_metadata)
                 self.discoverer._mark_used(ep)
-                self._last_chat_endpoint = ep.full_id
+                self._last_chat_endpoint = self._route_label(provider, ep.full_id)
                 return
             except Exception as exc:
                 self._mark_failed(ep)
@@ -243,6 +327,7 @@ class Assistant:
         # chat-sized model if the big one is cold/unreachable, so extraction
         # always produces something instead of hanging or returning nothing.
         extract_timeout = self.config.llm.task_extract_timeout or 30
+        request_metadata = self._router_request_metadata(context)
         task_eps = self._candidate_endpoints("task") or []
         chat_eps = self._candidate_endpoints("chat") or []
         pairs = [(ep, self._provider_for(ep) or self.provider) for ep in task_eps]
@@ -251,13 +336,19 @@ class Assistant:
             pairs = [(None, self.provider)]
         for ep, provider in pairs:
             try:
-                raw = provider.complete(prompt, timeout=extract_timeout).content
+                response = self._complete_provider(
+                    provider,
+                    prompt,
+                    timeout=extract_timeout,
+                    request_metadata=request_metadata,
+                )
                 if ep is not None:
                     self.discoverer._mark_used(ep)
-                    self._last_task_endpoint = ep.full_id
+                    self._last_task_endpoint = self._route_label(provider, ep.full_id)
                 else:
-                    self._last_task_endpoint = "config:" + getattr(self.provider, "model", "config")
-                return _parse_task_list(raw)
+                    fallback = "config:" + getattr(self.provider, "model", "config")
+                    self._last_task_endpoint = self._route_label(provider, fallback)
+                return _parse_task_list(response.content)
             except Exception as exc:
                 if ep is not None:
                     self._mark_failed(ep)
@@ -273,7 +364,7 @@ class Assistant:
         actor: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
-        user_id = (actor or {}).get("user_id", "scott")
+        user_id = (actor or {}).get("user_id")
         device_id = (actor or {}).get("device_id")
         for task in tasks:
             text = task.get("title") or task.get("description") or "Untitled task"

--- a/voice-agent/tests/test_auto_router_provider.py
+++ b/voice-agent/tests/test_auto_router_provider.py
@@ -251,7 +251,11 @@ def test_router_503_is_structured_and_never_implies_hosted_fallback(monkeypatch)
 
 def test_assistant_route_label_surfaces_selected_runtime_and_latency() -> None:
     assistant = object.__new__(Assistant)
-    provider = object()
+    provider = OpenAICompatProvider(
+        "http://auto-router:8088",
+        None,
+        "auto/fast",
+    )
     provider.last_route_metadata = {
         "provider": "xwing-lmstudio",
         "model": "qwen-local",

--- a/voice-agent/tests/test_auto_router_provider.py
+++ b/voice-agent/tests/test_auto_router_provider.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import pytest
 
 from voice_agent.llm.openai_compat_provider import (
+    LLMProviderError,
     OpenAICompatProvider,
     normalize_openai_base_url,
     validate_auto_router_base_url,
@@ -80,12 +81,18 @@ def test_validate_auto_router_base_url_rejects_invalid_url() -> None:
 @dataclass
 class _Response:
     payload: dict
+    status_code: int = 200
+    headers: dict[str, str] = field(default_factory=dict)
+    lines: list[bytes] = field(default_factory=list)
 
     def raise_for_status(self) -> None:
         return None
 
     def json(self) -> dict:
         return self.payload
+
+    def iter_lines(self):
+        yield from self.lines
 
 
 def test_task_alias_uses_single_v1_path_and_high_quality_model(monkeypatch) -> None:
@@ -95,7 +102,18 @@ def test_task_alias_uses_single_v1_path_and_high_quality_model(monkeypatch) -> N
         captured["url"] = url
         captured["payload"] = json
         captured["headers"] = headers
-        return _Response({"choices": [{"message": {"content": "[]"}}]})
+        return _Response(
+            {
+                "choices": [{"message": {"content": "[]"}}],
+                "auto_router": {
+                    "provider": "xwing-lmstudio",
+                    "model": "qwen-local",
+                    "stage": "final",
+                    "profile": "high-quality",
+                    "latency_ms": 321,
+                },
+            }
+        )
 
     monkeypatch.setattr(
         "voice_agent.llm.openai_compat_provider.requests.post",
@@ -108,9 +126,123 @@ def test_task_alias_uses_single_v1_path_and_high_quality_model(monkeypatch) -> N
         task_model="auto/high-quality",
     )
 
-    response = provider.complete("extract tasks")
+    response = provider.complete(
+        "extract tasks",
+        request_metadata={"session_id": "meeting-1"},
+    )
 
     assert response.content == "[]"
     assert captured["url"] == "http://auto-router:8088/v1/chat/completions"
     assert captured["payload"]["model"] == "auto/high-quality"
     assert captured["headers"]["Authorization"] == "Bearer local-offline-only"
+    metadata = captured["payload"]["metadata"]
+    assert metadata["workload_class"] == "task_extraction"
+    assert metadata["session_id"] == "meeting-1"
+    assert metadata["privacy"] == "personal"
+    assert metadata["local_only"] is True
+    assert metadata["allow_cloud"] is False
+    assert metadata["latency_target_ms"] == 10_000
+    assert metadata["correlation_id"]
+    assert response.metadata["provider"] == "xwing-lmstudio"
+    assert response.metadata["model"] == "qwen-local"
+    assert response.metadata["profile"] == "high-quality"
+    assert provider.last_route_metadata == response.metadata
+
+
+def test_stream_records_router_headers_and_ttft(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        captured["payload"] = json
+        return _Response(
+            {},
+            headers={
+                "X-Auto-Router-Provider": "destroyer-lmstudio",
+                "X-Auto-Router-Model": "qwen-fast",
+                "X-Auto-Router-Stage": "draft",
+                "X-Auto-Router-Profile": "fast",
+            },
+            lines=[
+                b'data: {"choices":[{"delta":{"content":"hello"}}]}',
+                b"data: [DONE]",
+            ],
+        )
+
+    monkeypatch.setattr(
+        "voice_agent.llm.openai_compat_provider.requests.post",
+        fake_post,
+    )
+    provider = OpenAICompatProvider(
+        "http://auto-router:8088",
+        None,
+        "auto/fast",
+    )
+
+    chunks = list(
+        provider.stream_complete(
+            [{"role": "user", "content": "hello"}],
+            request_metadata={"session_id": "voice-7"},
+        )
+    )
+
+    assert chunks == ["hello"]
+    assert captured["payload"]["metadata"]["workload_class"] == "interactive_voice"
+    assert captured["payload"]["metadata"]["session_id"] == "voice-7"
+    assert captured["payload"]["metadata"]["latency_target_ms"] == 1_500
+    assert provider.last_route_metadata["provider"] == "destroyer-lmstudio"
+    assert provider.last_route_metadata["model"] == "qwen-fast"
+    assert provider.last_route_metadata["stage"] == "draft"
+    assert provider.last_route_metadata["profile"] == "fast"
+    assert provider.last_route_metadata["ttft_ms"] >= 0
+    assert provider.last_route_metadata["latency_ms"] >= 0
+
+
+def test_non_router_payload_does_not_add_router_metadata(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        captured["payload"] = json
+        return _Response({"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr(
+        "voice_agent.llm.openai_compat_provider.requests.post",
+        fake_post,
+    )
+    provider = OpenAICompatProvider(
+        "https://api.openai.com/v1",
+        "secret",
+        "gpt-example",
+    )
+
+    provider.complete("hello")
+
+    assert "metadata" not in captured["payload"]
+
+
+def test_router_503_is_structured_and_never_implies_hosted_fallback(monkeypatch) -> None:
+    def fake_post(url, headers=None, json=None, timeout=None, **kwargs):
+        return _Response(
+            {"detail": {"error": "no admitted candidates"}},
+            status_code=503,
+            headers={"Retry-After": "12"},
+        )
+
+    monkeypatch.setattr(
+        "voice_agent.llm.openai_compat_provider.requests.post",
+        fake_post,
+    )
+    provider = OpenAICompatProvider(
+        "http://auto-router:8088",
+        None,
+        "auto/fast",
+    )
+
+    with pytest.raises(LLMProviderError) as exc_info:
+        provider.complete("hello")
+
+    exc = exc_info.value
+    assert exc.status_code == 503
+    assert exc.retry_after_seconds == 12
+    assert "not sent to a hosted provider" in str(exc)
+    assert provider.last_route_metadata["status_code"] == 503
+    assert provider.last_route_metadata["retry_after_seconds"] == 12

--- a/voice-agent/tests/test_auto_router_provider.py
+++ b/voice-agent/tests/test_auto_router_provider.py
@@ -10,6 +10,7 @@ from voice_agent.llm.openai_compat_provider import (
     normalize_openai_base_url,
     validate_auto_router_base_url,
 )
+from voice_agent.server.assistant import Assistant
 
 
 @pytest.mark.parametrize(
@@ -246,3 +247,50 @@ def test_router_503_is_structured_and_never_implies_hosted_fallback(monkeypatch)
     assert "not sent to a hosted provider" in str(exc)
     assert provider.last_route_metadata["status_code"] == 503
     assert provider.last_route_metadata["retry_after_seconds"] == 12
+
+
+def test_assistant_route_label_surfaces_selected_runtime_and_latency() -> None:
+    assistant = object.__new__(Assistant)
+    provider = object()
+    provider.last_route_metadata = {
+        "provider": "xwing-lmstudio",
+        "model": "qwen-local",
+        "profile": "fast",
+        "stage": "draft",
+        "ttft_ms": 81,
+        "latency_ms": 640,
+    }
+
+    label = assistant._route_label(provider, "config:auto/fast")
+
+    assert label == (
+        "router:xwing-lmstudio/qwen-local [fast:draft] "
+        "ttft=81ms latency=640ms"
+    )
+
+
+def test_ingested_task_without_actor_is_review_only_not_scott(monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_dispatch(payload):
+        captured["payload"] = payload
+        return {"sent": False, "error": "review only"}
+
+    monkeypatch.setattr(
+        "voice_agent.server.assistant.dispatch_to_assistx",
+        fake_dispatch,
+    )
+    assistant = object.__new__(Assistant)
+    assistant.db = None
+
+    assistant.ingest_tasks(
+        [{"title": "Review the deployment", "description": ""}],
+        actor=None,
+    )
+
+    payload = captured["payload"]
+    assert payload["actor"]["user_id"] == "unknown"
+    assert payload["actor"]["auth_state"] == "unknown_speaker"
+    assert payload["event_type"] == "task_proposed"
+    assert payload["auto_dispatch"] is False
+    assert payload["metadata"].get("user_id") is None


### PR DESCRIPTION
## Summary

Complete the next auto-router integration slice from #9 by making Sophia send explicit local/private workload metadata, retain the route decision returned by auto-router, and expose that decision through the existing chat metadata and `/status` surfaces.

## Changes

- Attach per-request correlation IDs, workload class, privacy, strict-local admission, priority, latency targets, and queue timestamps to `auto/*` requests.
- Propagate available session, correlation, device, user, activity, and timezone context without allowing callers to weaken local-only/privacy constraints.
- Preserve non-stream `auto_router` response metadata and stream route headers:
  - provider
  - model
  - stage
  - profile
  - correlation/session IDs
  - end-to-end latency
  - TTFT for streaming responses
- Extend `LLMResponse` with a backward-compatible metadata field.
- Store the most recent route result on the provider and render it into Sophia's existing streamed `meta.endpoint`, `last_chat_endpoint`, and `last_task_endpoint` diagnostics.
- Raise structured 429/503 errors with retry context and an explicit statement that strict-offline requests were not sent to a hosted provider.
- Keep non-router OpenAI-compatible payloads unchanged.
- Warn when the deprecated in-process fleet discovery path is explicitly enabled.
- Remove the remaining implicit Scott attribution from actorless extracted tasks; they now become `unknown_speaker`, `task_proposed`, and review-only.
- Expand the existing auto-router provider tests with QoS, provenance, TTFT, non-router compatibility, strict-offline 503, route-label, and fail-closed task attribution fixtures.

## Authority boundary

Sophia declares workload intent and privacy only. auto-router remains responsible for physical provider/model/node selection, admission, backpressure, and route provenance. AssistX remains responsible for canonical task and runtime authority.

## Validation

GitHub Actions run `30840754171` passed:

- `hardening-tests`
- `browser-smoke`

## Follow-up

#9 should remain open only for deleting the deprecated in-tree fleet discovery implementation/configuration and cleaning its stale deployment documentation after this PR lands.
