### PR TITLE
Fence Tailscale identity headers on legacy AssistX proxy

### DIFF
--- a/.github/workflows/voice-agent-hardening.yml
+++ b/.github/workflows/voice-agent-hardening.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Caddy configuration
+      - name: Parse Caddy configuration
         run: |
           docker run --rm \
             -v "$PWD/voice-agent/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
             caddy:2-alpine \
-            caddy validate --config /etc/caddy/Caddyfile
+            caddy adapt --config /etc/caddy/Caddyfile --adapter caddyfile > /dev/null
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/voice-agent-hardening.yml
+++ b/.github/workflows/voice-agent-hardening.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Caddy configuration
+        run: |
+          docker run --rm \
+            -v "$PWD/voice-agent/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            caddy:2-alpine \
+            caddy validate --config /etc/caddy/Caddyfile
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/voice-agent/caddy/Caddyfile
+++ b/voice-agent/caddy/Caddyfile
@@ -103,10 +103,20 @@ x1-370.tailcb8954.ts.net:8443 {
         reverse_proxy billing-service:3016
     }
     
-    # Auto-assist API (port 8000) — on auto-assist_default network  
+    # Legacy Auto-assist API path (port 8000) on auto-assist_default.
+    #
+    # This route is NOT the Kipnerter Tailnet-SSO authority. AssistX may trust
+    # Tailscale-User-Login only when traffic arrives through Tailscale Serve.
+    # Strip every Tailscale identity header Caddy could otherwise forward from
+    # an arbitrary :8443 client so this legacy path can only fall back to the
+    # normal AssistX auth mechanisms (for example Basic auth).
     @assistx path /assistx/*
     handle @assistx {
-        reverse_proxy assistx-api:8000
+        reverse_proxy assistx-api:8000 {
+            header_up -Tailscale-User-Login
+            header_up -Tailscale-User-Name
+            header_up -Tailscale-User-Profile-Pic
+        }
     }
 
     # Nextcloud — access via /nextcloud/* prefix since subdomain routing complex in Caddy v2


### PR DESCRIPTION
## Goal

Close the legacy Caddy path that can reach `assistx-api:8000` over Docker networking before AssistX enables trusted Tailscale identity headers for Kipnerter RC2.

## Why

The existing `:8443/assistx/*` reverse proxy bypasses the host-published port, so making host port 8000 loopback-only is not sufficient by itself. Kipnerter's authenticated mobile boundary must trust `Tailscale-User-Login` only when Tailscale Serve injected it.

## Change

The legacy Caddy AssistX proxy now removes:

- `Tailscale-User-Login`
- `Tailscale-User-Name`
- `Tailscale-User-Profile-Pic`

before forwarding to `assistx-api:8000`.

This preserves the legacy proxy and its normal AssistX authentication behavior while preventing arbitrary `:8443` clients from presenting themselves as a trusted Tailnet identity.

## Paired rollout

Paired backend: `scottjoyner/auto-assist#38`  
Paired iOS: `scottjoyner/kipnerter-ios#109`

Deploy/reload this Caddy change before enabling `TRUSTED_AUTH_HEADER=Tailscale-User-Login` on AssistX production.